### PR TITLE
Fixed bug in `RemoveAsync` by id

### DIFF
--- a/src/Core/Backend.Core.Marten.Tests/Backend.Core.Marten.Tests.csproj
+++ b/src/Core/Backend.Core.Marten.Tests/Backend.Core.Marten.Tests.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.2.0" />
-    <PackageReference Include="Marten" Version="2.7.1" />
+    <PackageReference Include="Marten" Version="2.8.0" />
     <PackageReference Include="MediatR" Version="4.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />

--- a/src/Core/Backend.Core.Marten/Backend.Core.Marten.csproj
+++ b/src/Core/Backend.Core.Marten/Backend.Core.Marten.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>5.1.0</Version>
+    <Version>5.1.1</Version>
     <PackageId>GoldenEye.Backend.Core.Marten</PackageId>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Oskar Dudycz</Authors>
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Marten" Version="2.7.1" />
+    <PackageReference Include="Marten" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/Backend.Core.Marten/Changelog.md
+++ b/src/Core/Backend.Core.Marten/Changelog.md
@@ -1,10 +1,16 @@
-﻿# v5.1.0 (12.05.2018) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/61)
+﻿# v5.1.1 (12.05.2018) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/62)
+
+## Changes
+
+* Fixed bug in `RemoveAsync` by id, that was selecting document of type Guid instead TEntity **[PATCH]**
+* Updated Marten to `2.8.0` **[PATCH]**
+
+# v5.1.0 (12.05.2018) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/61)
 
 ## Changes
 
 * Added `Remove` and `RemoveAsync` methods by id to `MartenDocumentDataContext` **[MINOR]**
 * Updated reference to Backend.Core **[PATCH]**
-
 
 # v5.0.0 (12.05.2018) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/60)
 

--- a/src/Core/Backend.Core.Marten/Context/MartenDocumentDataContext.cs
+++ b/src/Core/Backend.Core.Marten/Context/MartenDocumentDataContext.cs
@@ -103,14 +103,12 @@ namespace GoldenEye.Backend.Core.Marten.Context
 
         public Task<TEntity> RemoveAsync<TEntity>(TEntity entity, int? version = null, CancellationToken cancellationToken = default(CancellationToken)) where TEntity : class
         {
-            _documentSession.Delete(entity);
-            return Task.FromResult(entity);
+            return Task.FromResult(Remove(entity));
         }
 
         public Task<bool> RemoveAsync<TEntity>(object id, int? version = null, CancellationToken cancellationToken = default(CancellationToken)) where TEntity : class
         {
-            _documentSession.Delete(id);
-            return Task.FromResult(true);
+            return Task.FromResult(Remove<TEntity>(id, version));
         }
 
         public int SaveChanges()

--- a/src/Sample/DDD/Backend.DDD.Sample.Contracts/Changelog.md
+++ b/src/Sample/DDD/Backend.DDD.Sample.Contracts/Changelog.md
@@ -1,4 +1,11 @@
-﻿# v3.0.7 (07.04.2018) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/53)
+﻿# v3.0.8 (12.05.2018) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/62)
+
+## Changes
+
+* updated Marten packages version to most recent **[PATCH]**
+
+
+# v3.0.7 (07.04.2018) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/53)
 
 ## Changes
 

--- a/src/Sample/DDD/Backend.DDD.Sample.IntegrationTests/Changelog.md
+++ b/src/Sample/DDD/Backend.DDD.Sample.IntegrationTests/Changelog.md
@@ -1,4 +1,10 @@
-﻿# v4.0.1 (18.04.2018) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/57)
+﻿# v4.0.2 (12.05.2018) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/62)
+
+## Changes
+
+* updated Marten packages version to most recent **[PATCH]**
+
+# v4.0.1 (18.04.2018) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/57)
 
 ## Changes
 

--- a/src/Sample/DDD/Backend.DDD.Sample/Backend.DDD.Sample.csproj
+++ b/src/Sample/DDD/Backend.DDD.Sample/Backend.DDD.Sample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="6.2.2" />
-    <PackageReference Include="Marten" Version="2.7.1" />
+    <PackageReference Include="Marten" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sample/DDD/Backend.DDD.Sample/Changelog.md
+++ b/src/Sample/DDD/Backend.DDD.Sample/Changelog.md
@@ -1,4 +1,11 @@
-﻿# v5.0.0 (19.04.2018) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/58)
+﻿# v5.0.1 (12.05.2018) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/62)
+
+## Changes
+
+* updated Marten packages version to most recent **[PATCH]**
+
+
+# v5.0.0 (19.04.2018) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/58)
 
 ## Changes
 


### PR DESCRIPTION
Fixed bug in `RemoveAsync` by id, that was selecting document of type Guid instead TEntity
Updated Marten to `2.8.0`