### PR TITLE
Fixed bug for automatic registration of handlers and modules when generic handler implementation exists

### DIFF
--- a/src/Core/Backend.Core.DDD/Backend.Core.DDD.csproj
+++ b/src/Core/Backend.Core.DDD/Backend.Core.DDD.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <Version>9.0.0</Version>
+        <Version>9.0.1</Version>
         <PackageId>GoldenEye.Backend.Core.DDD</PackageId>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <Authors>Oskar Dudycz</Authors>

--- a/src/Core/Backend.Core.DDD/Changelog.md
+++ b/src/Core/Backend.Core.DDD/Changelog.md
@@ -1,3 +1,9 @@
+# v9.0.1 (20.07.2019) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/72)
+
+## Changes
+
+* Fixed bug for automatic registration of handlers and modules when generic handler implementation exists **[PATCH]**
+
 # v9.0.0 (20.07.2019) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/71)
 
 ## Changes

--- a/src/Core/Backend.Core.DDD/Registration/Registration.cs
+++ b/src/Core/Backend.Core.DDD/Registration/Registration.cs
@@ -1,4 +1,4 @@
-﻿using GoldenEye.Backend.Core.DDD.Commands;
+using GoldenEye.Backend.Core.DDD.Commands;
 using GoldenEye.Backend.Core.DDD.Events;
 using GoldenEye.Backend.Core.DDD.Events.Logging;
 using GoldenEye.Backend.Core.DDD.Events.Store;
@@ -78,10 +78,10 @@ namespace GoldenEye.Backend.Core.DDD.Registration
         {
             services.Scan(scan => scan
                 .FromAssemblies(from)
-                .AddClasses(classes => classes.AssignableTo(typeof(ICommandHandler<>)))
-                    .AsSelfWithInterfaces()
-                    .WithLifetime(withLifetime)
-                 );
+                .AddClasses(classes => classes.AssignableTo(typeof(ICommandHandler<>)).Where(c => !c.IsAbstract && !c.IsGenericTypeDefinition))
+                .AsSelfWithInterfaces()
+                .WithLifetime(withLifetime)
+            );
 
             return services;
         }
@@ -93,10 +93,10 @@ namespace GoldenEye.Backend.Core.DDD.Registration
         {
             services.Scan(scan => scan
                 .FromAssemblies(from)
-                .AddClasses(classes => classes.AssignableTo(typeof(IQueryHandler<,>)))
-                    .AsSelfWithInterfaces()
-                    .WithLifetime(withLifetime)
-                 );
+                .AddClasses(classes => classes.AssignableTo(typeof(IQueryHandler<,>)).Where(c => !c.IsAbstract && !c.IsGenericTypeDefinition))
+                .AsSelfWithInterfaces()
+                .WithLifetime(withLifetime)
+            );
 
             return services;
         }
@@ -108,10 +108,10 @@ namespace GoldenEye.Backend.Core.DDD.Registration
         {
             services.Scan(scan => scan
                 .FromAssemblies(from)
-                .AddClasses(classes => classes.AssignableTo(typeof(IEventHandler<>)).NotInNamespaceOf(typeof(EventStorePipeline<>)))
-                    .AsSelfWithInterfaces()
-                    .WithLifetime(withLifetime)
-                 );
+                .AddClasses(classes => classes.AssignableTo(typeof(IEventHandler<>)).Where(c => !c.IsAbstract && !c.IsGenericTypeDefinition))
+                .AsSelfWithInterfaces()
+                .WithLifetime(withLifetime)
+            );
 
             return services;
         }

--- a/src/Core/Backend.Core.Marten/Backend.Core.Marten.csproj
+++ b/src/Core/Backend.Core.Marten/Backend.Core.Marten.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <Version>8.0.0</Version>
+        <Version>8.0.1</Version>
         <PackageId>GoldenEye.Backend.Core.Marten</PackageId>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <Authors>Oskar Dudycz</Authors>

--- a/src/Core/Backend.Core.Marten/Changelog.md
+++ b/src/Core/Backend.Core.Marten/Changelog.md
@@ -1,3 +1,9 @@
+# v8.0.1 (20.07.2019) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/72)
+
+## Changes
+
+* Updated `Backend.Core.DDD` to `9.0.1` **[PATCH]**
+
 # v8.0.0 (20.07.2019) [Pull Request](https://github.com/oskardudycz/GoldenEye/pull/71)
 
 ## Changes

--- a/src/Templates/SimpleDDD/content/GoldenEye.WebApi.Template.SimpleDDD.csproj
+++ b/src/Templates/SimpleDDD/content/GoldenEye.WebApi.Template.SimpleDDD.csproj
@@ -12,11 +12,11 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="8.1.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="6.1.1" />
-    <PackageReference Include="GoldenEye.Backend.Core" Version="7.0.0" />
-    <PackageReference Include="GoldenEye.Backend.Core.DDD" Version="8.0.0" />
-    <PackageReference Include="GoldenEye.Backend.Core.Marten" Version="7.0.0" />
-    <PackageReference Include="GoldenEye.Backend.Core.WebApi" Version="7.0.0" />
-    <PackageReference Include="GoldenEye.Shared.Core" Version="6.0.0" />
+    <PackageReference Include="GoldenEye.Backend.Core" Version="7.1.0" />
+    <PackageReference Include="GoldenEye.Backend.Core.DDD" Version="9.0.0" />
+    <PackageReference Include="GoldenEye.Backend.Core.Marten" Version="8.0.0" />
+    <PackageReference Include="GoldenEye.Backend.Core.WebApi" Version="7.1.0" />
+    <PackageReference Include="GoldenEye.Shared.Core" Version="6.1.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
   </ItemGroup>

--- a/src/Templates/SimpleDDD/content/Startup.cs
+++ b/src/Templates/SimpleDDD/content/Startup.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using AutoMapper;
 using GoldenEye.Backend.Core.DDD.Registration;
 using GoldenEye.Backend.Core.WebApi.Modules;
 using GoldenEye.Backend.Core.WebApi.Registration;
 using GoldenEye.Shared.Core.Configuration;
+using GoldenEye.Shared.Core.Mappings;
 using GoldenEye.Shared.Core.Modules;
-using GoldenEye.WebApi.Template.SimpleDDD.Backend;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -28,10 +26,12 @@ namespace GoldenEye.WebApi.Template.SimpleDDD
             services.AddMvc();
             services.AddDDD();
 
-            services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
+            services.AddAllDDDHandlers();
+
+            services.AddAutoMapperForAllDependencies();
             services.AddConfiguration(Configuration);
 
-            services.AddModule<BackendModule>();
+            services.AddAllModules();
             services.AddModule<AllowAllCorsModule>();
             services.AddModule<SwaggerModule>();
         }


### PR DESCRIPTION
# GoldenEye.Backend.Core.DDD - v9.0.1
# GoldenEye.Backend.Core.Marten - v8.0.1

- Fixed bug for automatic registration of handlers and modules when generic handler implementation exists.
- Updated packages versions in template project