### PR TITLE
added fix for Kafka producer registration

### DIFF
--- a/src/Kafka/Kafka/Registrations/Registration.cs
+++ b/src/Kafka/Kafka/Registrations/Registration.cs
@@ -1,10 +1,10 @@
-using Core.Streaming.Kafka.Consumers;
 using GoldenEye.Events.External;
 using GoldenEye.Kafka.Consumers;
 using GoldenEye.Kafka.Producers;
 using GoldenEye.Registration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using System.Linq;
 
 namespace GoldenEye.Kafka.Registrations
 {
@@ -13,6 +13,10 @@ namespace GoldenEye.Kafka.Registrations
 
         public static IServiceCollection AddKafkaProducer(this IServiceCollection services)
         {
+            //removing NulloExternalEventProducer added by default
+            var serviceDescriptor = services.FirstOrDefault(descriptor => descriptor.ServiceType == typeof(IExternalEventProducer));
+            services.Remove(serviceDescriptor);
+
             //using TryAdd to support mocking, without that it won't be possible to override in tests
             services.TryAddScoped<IExternalEventProducer, KafkaProducer>();
             return services;


### PR DESCRIPTION
The AddKafkaProducer function doesn't add a KafkaProducer when IExternalEventProducer is already registered.
I remove the implementation NulloExternalEventProducer  already registered before registering KafkaProducer.