### PR TITLE
Added an extra method PublishParallel to IEventBus.

### DIFF
--- a/src/Core/Core/Events/IEventBus.cs
+++ b/src/Core/Core/Events/IEventBus.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace GoldenEye.Events
@@ -6,6 +6,7 @@ namespace GoldenEye.Events
     public interface IEventBus
     {
         Task Publish(CancellationToken cancellationToken, params IEvent[] events);
+        Task PublishParallel(CancellationToken cancellationToken, params IEvent[] events);
         Task Publish<TEvent>(TEvent @event, CancellationToken cancellationToken = default) where TEvent : IEvent;
     }
 }


### PR DESCRIPTION
- This is to provide a mechanism to publish multiple events in parallel if the order of the events is not important. This is especially needed when events are used as pure notifications.
- This is an addition so it is backwards compatible. 